### PR TITLE
Add Chat View To Plugins List

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3838,5 +3838,12 @@
         "author": "Johnson0907",
         "description": "Help you to view some recent daily notes on one page.",
         "repo": "Johnson0907/obsidian-daily-notes-viewer"
+    },
+    {
+        "id": "obsidian-chat-view",
+        "name": "Chat View",
+        "author": "Aditya Majethia",
+        "description": "Chat View lets you quickly and easily create elegant Chat UIs in your Markdown Files.",
+        "repo": "adifyr/obsidian-chat-view"
     }
 ]


### PR DESCRIPTION
This commit adds the Obsidian Chat View plugin to the plugins list in community-plugins.json.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/adifyr/obsidian-chat-view

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
